### PR TITLE
Navigation changed to new homepage.

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -5,19 +5,25 @@ import 'package:wordspro/bloc/locale/locale_bloc.dart';
 import 'package:wordspro/bloc/theme/theme_bloc.dart';
 import 'package:wordspro/data/repositories.dart';
 import 'package:wordspro/presentation/pages/game/game_page.dart';
+import 'package:wordspro/presentation/pages/start/start_page.dart';
 import 'package:wordspro/presentation/pages/tutorial/tutorial_page.dart';
 import 'package:wordspro/resources/resources.dart';
 
 class App extends StatelessWidget {
-  const App({super.key});
+  const App({this.startOnStartPage = false, super.key});
+
+  /// Whether the app should open on the start page.
+  final bool startOnStartPage;
 
   @override
   Widget build(BuildContext context) {
     final isSecondLaunch =
         context.read<ISaveSettingsRepository>().isSecondLaunch;
+
     return BlocBuilder<ThemeBloc, ThemeState>(
       builder: (context, themeState) => BlocBuilder<LocaleBloc, LocaleState>(
         builder: (context, localeState) => MaterialApp(
+          debugShowCheckedModeBanner: false,
           locale: localeState.locale.locale,
           theme: themeState.isDarkTheme ? darkTheme : lightTheme,
           localizationsDelegates: const [
@@ -28,8 +34,9 @@ class App extends StatelessWidget {
           ],
           supportedLocales: R.delegate.supportedLocales,
           onGenerateTitle: (context) => context.r.wordspro_plus,
-          debugShowCheckedModeBanner: false,
-          home: isSecondLaunch ? const GamePage() : const TutorialPage(),
+          home: startOnStartPage
+              ? const StartPage()
+              : (isSecondLaunch ? const GamePage() : const TutorialPage()),
         ),
       ),
     );

--- a/lib/bloc/game/game_bloc.freezed.dart
+++ b/lib/bloc/game/game_bloc.freezed.dart
@@ -19,7 +19,7 @@ mixin _$GameEvent {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(KeyboardKeys letter) letterPressed,
-    required TResult Function(RawKeyDownEvent keyDown) keyListen,
+    required TResult Function(KeyEvent keyDown) keyListen,
     required TResult Function() deletePressed,
     required TResult Function() deleteLongPressed,
     required TResult Function() enterPressed,
@@ -31,7 +31,7 @@ mixin _$GameEvent {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(KeyboardKeys letter)? letterPressed,
-    TResult? Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult? Function(KeyEvent keyDown)? keyListen,
     TResult? Function()? deletePressed,
     TResult? Function()? deleteLongPressed,
     TResult? Function()? enterPressed,
@@ -43,7 +43,7 @@ mixin _$GameEvent {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(KeyboardKeys letter)? letterPressed,
-    TResult Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult Function(KeyEvent keyDown)? keyListen,
     TResult Function()? deletePressed,
     TResult Function()? deleteLongPressed,
     TResult Function()? enterPressed,
@@ -184,7 +184,7 @@ class _$LetterPressedEventImpl extends _LetterPressedEvent
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(KeyboardKeys letter) letterPressed,
-    required TResult Function(RawKeyDownEvent keyDown) keyListen,
+    required TResult Function(KeyEvent keyDown) keyListen,
     required TResult Function() deletePressed,
     required TResult Function() deleteLongPressed,
     required TResult Function() enterPressed,
@@ -199,7 +199,7 @@ class _$LetterPressedEventImpl extends _LetterPressedEvent
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(KeyboardKeys letter)? letterPressed,
-    TResult? Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult? Function(KeyEvent keyDown)? keyListen,
     TResult? Function()? deletePressed,
     TResult? Function()? deleteLongPressed,
     TResult? Function()? enterPressed,
@@ -214,7 +214,7 @@ class _$LetterPressedEventImpl extends _LetterPressedEvent
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(KeyboardKeys letter)? letterPressed,
-    TResult Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult Function(KeyEvent keyDown)? keyListen,
     TResult Function()? deletePressed,
     TResult Function()? deleteLongPressed,
     TResult Function()? enterPressed,
@@ -296,7 +296,7 @@ abstract class _$$KeyListenEventImplCopyWith<$Res> {
           $Res Function(_$KeyListenEventImpl) then) =
       __$$KeyListenEventImplCopyWithImpl<$Res>;
   @useResult
-  $Res call({RawKeyDownEvent keyDown});
+  $Res call({KeyEvent keyDown});
 }
 
 /// @nodoc
@@ -316,7 +316,7 @@ class __$$KeyListenEventImplCopyWithImpl<$Res>
       null == keyDown
           ? _value.keyDown
           : keyDown // ignore: cast_nullable_to_non_nullable
-              as RawKeyDownEvent,
+              as KeyEvent,
     ));
   }
 }
@@ -328,7 +328,7 @@ class _$KeyListenEventImpl extends _KeyListenEvent
   const _$KeyListenEventImpl(this.keyDown) : super._();
 
   @override
-  final RawKeyDownEvent keyDown;
+  final KeyEvent keyDown;
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
@@ -365,7 +365,7 @@ class _$KeyListenEventImpl extends _KeyListenEvent
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(KeyboardKeys letter) letterPressed,
-    required TResult Function(RawKeyDownEvent keyDown) keyListen,
+    required TResult Function(KeyEvent keyDown) keyListen,
     required TResult Function() deletePressed,
     required TResult Function() deleteLongPressed,
     required TResult Function() enterPressed,
@@ -380,7 +380,7 @@ class _$KeyListenEventImpl extends _KeyListenEvent
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(KeyboardKeys letter)? letterPressed,
-    TResult? Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult? Function(KeyEvent keyDown)? keyListen,
     TResult? Function()? deletePressed,
     TResult? Function()? deleteLongPressed,
     TResult? Function()? enterPressed,
@@ -395,7 +395,7 @@ class _$KeyListenEventImpl extends _KeyListenEvent
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(KeyboardKeys letter)? letterPressed,
-    TResult Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult Function(KeyEvent keyDown)? keyListen,
     TResult Function()? deletePressed,
     TResult Function()? deleteLongPressed,
     TResult Function()? enterPressed,
@@ -461,11 +461,10 @@ class _$KeyListenEventImpl extends _KeyListenEvent
 }
 
 abstract class _KeyListenEvent extends GameEvent {
-  const factory _KeyListenEvent(final RawKeyDownEvent keyDown) =
-      _$KeyListenEventImpl;
+  const factory _KeyListenEvent(final KeyEvent keyDown) = _$KeyListenEventImpl;
   const _KeyListenEvent._() : super._();
 
-  RawKeyDownEvent get keyDown;
+  KeyEvent get keyDown;
   @JsonKey(ignore: true)
   _$$KeyListenEventImplCopyWith<_$KeyListenEventImpl> get copyWith =>
       throw _privateConstructorUsedError;
@@ -517,7 +516,7 @@ class _$DeletePressedEventImpl extends _DeletePressedEvent
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(KeyboardKeys letter) letterPressed,
-    required TResult Function(RawKeyDownEvent keyDown) keyListen,
+    required TResult Function(KeyEvent keyDown) keyListen,
     required TResult Function() deletePressed,
     required TResult Function() deleteLongPressed,
     required TResult Function() enterPressed,
@@ -532,7 +531,7 @@ class _$DeletePressedEventImpl extends _DeletePressedEvent
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(KeyboardKeys letter)? letterPressed,
-    TResult? Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult? Function(KeyEvent keyDown)? keyListen,
     TResult? Function()? deletePressed,
     TResult? Function()? deleteLongPressed,
     TResult? Function()? enterPressed,
@@ -547,7 +546,7 @@ class _$DeletePressedEventImpl extends _DeletePressedEvent
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(KeyboardKeys letter)? letterPressed,
-    TResult Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult Function(KeyEvent keyDown)? keyListen,
     TResult Function()? deletePressed,
     TResult Function()? deleteLongPressed,
     TResult Function()? enterPressed,
@@ -666,7 +665,7 @@ class _$DeleteLongPressedEventImpl extends _DeleteLongPressedEvent
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(KeyboardKeys letter) letterPressed,
-    required TResult Function(RawKeyDownEvent keyDown) keyListen,
+    required TResult Function(KeyEvent keyDown) keyListen,
     required TResult Function() deletePressed,
     required TResult Function() deleteLongPressed,
     required TResult Function() enterPressed,
@@ -681,7 +680,7 @@ class _$DeleteLongPressedEventImpl extends _DeleteLongPressedEvent
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(KeyboardKeys letter)? letterPressed,
-    TResult? Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult? Function(KeyEvent keyDown)? keyListen,
     TResult? Function()? deletePressed,
     TResult? Function()? deleteLongPressed,
     TResult? Function()? enterPressed,
@@ -696,7 +695,7 @@ class _$DeleteLongPressedEventImpl extends _DeleteLongPressedEvent
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(KeyboardKeys letter)? letterPressed,
-    TResult Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult Function(KeyEvent keyDown)? keyListen,
     TResult Function()? deletePressed,
     TResult Function()? deleteLongPressed,
     TResult Function()? enterPressed,
@@ -812,7 +811,7 @@ class _$EnterPressedEventImpl extends _EnterPressedEvent
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(KeyboardKeys letter) letterPressed,
-    required TResult Function(RawKeyDownEvent keyDown) keyListen,
+    required TResult Function(KeyEvent keyDown) keyListen,
     required TResult Function() deletePressed,
     required TResult Function() deleteLongPressed,
     required TResult Function() enterPressed,
@@ -827,7 +826,7 @@ class _$EnterPressedEventImpl extends _EnterPressedEvent
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(KeyboardKeys letter)? letterPressed,
-    TResult? Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult? Function(KeyEvent keyDown)? keyListen,
     TResult? Function()? deletePressed,
     TResult? Function()? deleteLongPressed,
     TResult? Function()? enterPressed,
@@ -842,7 +841,7 @@ class _$EnterPressedEventImpl extends _EnterPressedEvent
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(KeyboardKeys letter)? letterPressed,
-    TResult Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult Function(KeyEvent keyDown)? keyListen,
     TResult Function()? deletePressed,
     TResult Function()? deleteLongPressed,
     TResult Function()? enterPressed,
@@ -997,7 +996,7 @@ class _$LoadGameEventImpl extends _LoadGameEvent with DiagnosticableTreeMixin {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(KeyboardKeys letter) letterPressed,
-    required TResult Function(RawKeyDownEvent keyDown) keyListen,
+    required TResult Function(KeyEvent keyDown) keyListen,
     required TResult Function() deletePressed,
     required TResult Function() deleteLongPressed,
     required TResult Function() enterPressed,
@@ -1012,7 +1011,7 @@ class _$LoadGameEventImpl extends _LoadGameEvent with DiagnosticableTreeMixin {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(KeyboardKeys letter)? letterPressed,
-    TResult? Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult? Function(KeyEvent keyDown)? keyListen,
     TResult? Function()? deletePressed,
     TResult? Function()? deleteLongPressed,
     TResult? Function()? enterPressed,
@@ -1027,7 +1026,7 @@ class _$LoadGameEventImpl extends _LoadGameEvent with DiagnosticableTreeMixin {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(KeyboardKeys letter)? letterPressed,
-    TResult Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult Function(KeyEvent keyDown)? keyListen,
     TResult Function()? deletePressed,
     TResult Function()? deleteLongPressed,
     TResult Function()? enterPressed,
@@ -1178,7 +1177,7 @@ class _$ShareEventImpl extends _ShareEvent with DiagnosticableTreeMixin {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(KeyboardKeys letter) letterPressed,
-    required TResult Function(RawKeyDownEvent keyDown) keyListen,
+    required TResult Function(KeyEvent keyDown) keyListen,
     required TResult Function() deletePressed,
     required TResult Function() deleteLongPressed,
     required TResult Function() enterPressed,
@@ -1193,7 +1192,7 @@ class _$ShareEventImpl extends _ShareEvent with DiagnosticableTreeMixin {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(KeyboardKeys letter)? letterPressed,
-    TResult? Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult? Function(KeyEvent keyDown)? keyListen,
     TResult? Function()? deletePressed,
     TResult? Function()? deleteLongPressed,
     TResult? Function()? enterPressed,
@@ -1208,7 +1207,7 @@ class _$ShareEventImpl extends _ShareEvent with DiagnosticableTreeMixin {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(KeyboardKeys letter)? letterPressed,
-    TResult Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult Function(KeyEvent keyDown)? keyListen,
     TResult Function()? deletePressed,
     TResult Function()? deleteLongPressed,
     TResult Function()? enterPressed,
@@ -1361,7 +1360,7 @@ class _$ChangeDictionaryEventImpl extends _ChangeDictionaryEvent
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(KeyboardKeys letter) letterPressed,
-    required TResult Function(RawKeyDownEvent keyDown) keyListen,
+    required TResult Function(KeyEvent keyDown) keyListen,
     required TResult Function() deletePressed,
     required TResult Function() deleteLongPressed,
     required TResult Function() enterPressed,
@@ -1376,7 +1375,7 @@ class _$ChangeDictionaryEventImpl extends _ChangeDictionaryEvent
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(KeyboardKeys letter)? letterPressed,
-    TResult? Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult? Function(KeyEvent keyDown)? keyListen,
     TResult? Function()? deletePressed,
     TResult? Function()? deleteLongPressed,
     TResult? Function()? enterPressed,
@@ -1391,7 +1390,7 @@ class _$ChangeDictionaryEventImpl extends _ChangeDictionaryEvent
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(KeyboardKeys letter)? letterPressed,
-    TResult Function(RawKeyDownEvent keyDown)? keyListen,
+    TResult Function(KeyEvent keyDown)? keyListen,
     TResult Function()? deletePressed,
     TResult Function()? deleteLongPressed,
     TResult Function()? enterPressed,

--- a/lib/bloc/game/game_event.dart
+++ b/lib/bloc/game/game_event.dart
@@ -9,7 +9,7 @@ class GameEvent with _$GameEvent {
   const factory GameEvent.letterPressed(KeyboardKeys letter) =
       _LetterPressedEvent;
 
-  const factory GameEvent.keyListen(RawKeyDownEvent keyDown) = _KeyListenEvent;
+  const factory GameEvent.keyListen(KeyEvent keyDown) = _KeyListenEvent;
 
   const factory GameEvent.deletePressed() = _DeletePressedEvent;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,6 @@ import 'package:wordspro/bloc/locale/locale_bloc.dart';
 import 'package:wordspro/bloc/theme/theme_bloc.dart';
 import 'package:wordspro/data/repositories.dart';
 
-
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
@@ -21,13 +20,13 @@ Future<void> main() async {
     DeviceOrientation.portraitUp,
     DeviceOrientation.portraitDown,
   ]);
+
   setPathUrlStrategy();
-
-
 
   runZonedGuarded<void>(
     () async {
       Bloc.observer = const AppBlocObserver();
+
       final ISaveGameRepository gameRepo = SaveGameRepository();
       final ISaveStatisticRepository statisticRepo = SaveStatisticRepository();
       final ISaveLevelsRepository levelsRepo = SaveLevelsRepository();
@@ -43,17 +42,13 @@ Future<void> main() async {
         MultiRepositoryProvider(
           providers: [
             RepositoryProvider<ISaveGameRepository>(
-              create: (context) => gameRepo,
-            ),
+                create: (context) => gameRepo),
             RepositoryProvider<ISaveStatisticRepository>(
-              create: (context) => statisticRepo,
-            ),
+                create: (context) => statisticRepo),
             RepositoryProvider<ISaveLevelsRepository>(
-              create: (context) => levelsRepo,
-            ),
+                create: (context) => levelsRepo),
             RepositoryProvider<ISaveSettingsRepository>(
-              create: (context) => settingsRepo,
-            ),
+                create: (context) => settingsRepo),
           ],
           child: MultiBlocProvider(
             providers: [
@@ -85,7 +80,8 @@ Future<void> main() async {
                 )..add(const GameEvent.loadGame()),
               ),
             ],
-            child: const App(),
+            child:
+                const App(startOnStartPage: true), // <-- Start page integration
           ),
         ),
       );

--- a/lib/presentation/pages/game/game_page.dart
+++ b/lib/presentation/pages/game/game_page.dart
@@ -41,13 +41,12 @@ class _GamePageState extends State<GamePage> {
   }
 
   @override
-  Widget build(BuildContext context) => RawKeyboardListener(
+  Widget build(BuildContext context) => KeyboardListener(
         autofocus: true,
         focusNode: _focusNode,
-        onKey: (event) {
-          if (event is RawKeyDownEvent) {
+        onKeyEvent: (KeyEvent event) {
+          if (event is KeyDownEvent) {
             context.read<GameBloc>().add(GameEvent.keyListen(event));
-            return;
           }
         },
         child: BlocListener<GameBloc, GameState>(
@@ -65,6 +64,7 @@ class _GamePageState extends State<GamePage> {
                 ),
               );
             }
+
             late bool daily;
             final gameResult = state.mapOrNull(
               complete: (s) {
@@ -72,6 +72,7 @@ class _GamePageState extends State<GamePage> {
                 return s.result;
               },
             );
+
             if (gameResult != null) {
               showGameResultDialog(
                 context,
@@ -83,6 +84,7 @@ class _GamePageState extends State<GamePage> {
           child: Scaffold(
             drawer: const CustomDrawer(),
             appBar: CustomAppBar(
+              key: UniqueKey(), // optional key added
               title: widget.isDailyMode
                   ? context.r.daily
                   : context.r.level_number(
@@ -103,7 +105,7 @@ class _GamePageState extends State<GamePage> {
                   ),
               ],
             ),
-            body: const _GameBody(),
+            body: _GameBody(key: UniqueKey()), // added key, removed const
           ),
         ),
       );
@@ -148,7 +150,6 @@ class _GamePageState extends State<GamePage> {
 }
 
 class _GameBody extends StatelessWidget {
-  // ignore: unused_element
   const _GameBody({super.key});
 
   @override

--- a/lib/presentation/pages/start/start_page.dart
+++ b/lib/presentation/pages/start/start_page.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wordspro/bloc/theme/theme_bloc.dart';
+import 'package:wordspro/presentation/pages/game/game_page.dart';
+import 'package:wordspro/presentation/pages/levels/levels_page.dart';
+import 'package:wordspro/presentation/pages/settings/settings_page.dart';
+import 'package:wordspro/presentation/pages/credits/credits_page.dart';
+import 'package:wordspro/presentation/pages/tutorial/tutorial_page.dart';
+
+class StartPage extends StatelessWidget {
+  const StartPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+
+    return BlocBuilder<ThemeBloc, ThemeState>(
+      builder: (context, themeState) {
+        final theme = Theme.of(context);
+        return Scaffold(
+          backgroundColor: theme.scaffoldBackgroundColor,
+          body: SafeArea(
+            child: Stack(
+              children: [
+                // Top right buttons: About and Settings
+                Positioned(
+                  top: 16,
+                  right: 16,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.info_outline),
+                        tooltip: 'About',
+                        color: theme.iconTheme.color,
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const CreditsPage(),
+                            ),
+                          );
+                        },
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.settings),
+                        tooltip: 'Settings',
+                        color: theme.iconTheme.color,
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const SettingsPage(),
+                            ),
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+
+                // Main content
+                Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    // Placeholder logo
+                    SizedBox(
+                      height: size.height * 0.3,
+                      child: const Center(
+                        child: FlutterLogo(size: 120),
+                      ),
+                    ),
+                    const Spacer(),
+
+                    // Buttons
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 32.0),
+                      child: Column(
+                        children: [
+                          SizedBox(
+                            width: double.infinity,
+                            child: ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: theme.colorScheme.primary,
+                                foregroundColor: theme.colorScheme.onPrimary,
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 16),
+                              ),
+                              onPressed: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) =>
+                                        const GamePage(isDailyMode: true),
+                                  ),
+                                );
+                              },
+                              child: Text(
+                                'Daily',
+                                style: theme.textTheme.titleMedium,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          SizedBox(
+                            width: double.infinity,
+                            child: ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: theme.colorScheme.primary,
+                                foregroundColor: theme.colorScheme.onPrimary,
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 16),
+                              ),
+                              onPressed: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) => const LevelsPage(),
+                                  ),
+                                );
+                              },
+                              child: Text(
+                                'Levels',
+                                style: theme.textTheme.titleMedium,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          SizedBox(
+                            width: double.infinity,
+                            child: ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: theme.colorScheme.primary,
+                                foregroundColor: theme.colorScheme.onPrimary,
+                                padding:
+                                    const EdgeInsets.symmetric(vertical: 16),
+                              ),
+                              onPressed: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) => const TutorialPage(),
+                                  ),
+                                );
+                              },
+                              child: Text(
+                                'How to Play',
+                                style: theme.textTheme.titleMedium,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 32),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/resources/dark_theme.dart
+++ b/lib/resources/dark_theme.dart
@@ -2,12 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:wordspro/resources/colors.dart';
 
-final _base = ThemeData.dark(useMaterial3: true);
-
-final darkTheme = _base.copyWith(
-  useMaterial3: true,
+final darkTheme = ThemeData.from(
+  colorScheme: const ColorScheme.dark(
+    primary: AppColors.dark,
+    secondary: AppColors.light,
+    surface: AppColors.dark, // instead of background
+  ),
+  textTheme: GoogleFonts.ubuntuTextTheme(),
+).copyWith(
   scaffoldBackgroundColor: AppColors.dark,
-  textTheme: GoogleFonts.ubuntuTextTheme(_base.textTheme).copyWith(
+  textTheme: GoogleFonts.ubuntuTextTheme().copyWith(
     titleLarge: const TextStyle(
       fontSize: 24,
       fontWeight: FontWeight.w700,
@@ -31,15 +35,12 @@ final darkTheme = _base.copyWith(
   ),
   elevatedButtonTheme: ElevatedButtonThemeData(
     style: ButtonStyle(
-      padding: MaterialStateProperty.all(
-        const EdgeInsets.symmetric(
-          vertical: 12,
-          horizontal: 48,
-        ),
+      padding: WidgetStateProperty.all(
+        const EdgeInsets.symmetric(vertical: 12, horizontal: 48),
       ),
-      elevation: MaterialStateProperty.all(0),
-      foregroundColor: MaterialStateProperty.all(AppColors.dark),
-      backgroundColor: MaterialStateProperty.all(AppColors.light),
+      elevation: WidgetStateProperty.all(0),
+      foregroundColor: WidgetStateProperty.all(AppColors.dark),
+      backgroundColor: WidgetStateProperty.all(AppColors.light),
     ),
   ),
   textSelectionTheme: const TextSelectionThemeData(

--- a/lib/resources/light_theme.dart
+++ b/lib/resources/light_theme.dart
@@ -2,12 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:wordspro/resources/colors.dart';
 
-final _base = ThemeData.light(useMaterial3: true);
-
-final lightTheme = _base.copyWith(
-  useMaterial3: true,
+final lightTheme = ThemeData.from(
+  colorScheme: const ColorScheme.light(
+    primary: AppColors.light,
+    secondary: AppColors.dark,
+    surface: AppColors.light, // updated from background
+  ),
+  textTheme: GoogleFonts.ubuntuTextTheme(),
+).copyWith(
   scaffoldBackgroundColor: AppColors.light,
-  textTheme: GoogleFonts.ubuntuTextTheme(_base.textTheme).copyWith(
+  textTheme: GoogleFonts.ubuntuTextTheme().copyWith(
     titleLarge: const TextStyle(
       fontSize: 24,
       fontWeight: FontWeight.w700,
@@ -31,24 +35,21 @@ final lightTheme = _base.copyWith(
   ),
   elevatedButtonTheme: ElevatedButtonThemeData(
     style: ButtonStyle(
-      padding: MaterialStateProperty.all(
-        const EdgeInsets.symmetric(
-          vertical: 12,
-          horizontal: 48,
-        ),
+      padding: WidgetStateProperty.all(
+        const EdgeInsets.symmetric(vertical: 12, horizontal: 48),
       ),
-      elevation: MaterialStateProperty.all(0),
-      backgroundColor: MaterialStateProperty.all(AppColors.light),
+      elevation: WidgetStateProperty.all(0),
+      backgroundColor: WidgetStateProperty.all(AppColors.light),
     ),
-  ),
-  textSelectionTheme: const TextSelectionThemeData(
-    cursorColor: AppColors.greyLight,
-    selectionColor: AppColors.greyLight,
-    selectionHandleColor: AppColors.greyLight,
   ),
   appBarTheme: const AppBarTheme(
     elevation: 0,
     backgroundColor: AppColors.light,
     foregroundColor: AppColors.dark,
+  ),
+  textSelectionTheme: const TextSelectionThemeData(
+    cursorColor: AppColors.greyLight,
+    selectionColor: AppColors.greyLight,
+    selectionHandleColor: AppColors.greyLight,
   ),
 );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,9 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.6
+  flutter_lints: ^2.0.0
+  flutter_test:
+    sdk: flutter
   carapacik_lints:
   flutter_native_splash: ^2.3.2
   freezed: ^2.4.3

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,14 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:wordspro/main.dart';
+import 'package:wordspro/app/app.dart'; // your main app widget
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('App smoke test', (WidgetTester tester) async {
+    // Build your app
+    await tester.pumpWidget(const App());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Example: check if a widget with text "WordsPro" exists
+    // Adjust according to your actual UI
+    expect(find.text('WordsPro'), findsNothing); // replace with real content
   });
 }


### PR DESCRIPTION
ToDo:
- Fix 'about'
- Fix 'levels'
- Fix 'how to play' overflow

Further:
- Update 'daily' to have back button instead of hamburger menu -- returns to the start page
- Remove side bar from all pages for now

Revenue:
- Integrate with Ads -- One after each fail/successful level, after daily, banner add on main screen and one below final guess row

- Possibly enable purchases to remove ads for 3.99 with the promise of free access to any new paid features as we add them